### PR TITLE
Switch checkout-action to cached one

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -26,10 +26,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          lfs: true
+      - name: Cached checkout
+        uses: nschloe/action-cached-lfs-checkout@v1
+        # Use these to explicitly include/exclude files:
+        # with:
+        #   include: "*"
+        #   exclude: ""
       - name: Setup Pages
         uses: actions/configure-pages@v3
       - name: Build with Jekyll


### PR DESCRIPTION
Every deployment use the LFS bandwith so we use cached checkout now.

Laut [Readme](https://github.com/marketplace/actions/cached-lfs-checkout) reicht ein einfaches Ersetzen von der bisherigen checkout-action durch die neue