### PR TITLE
Make auto darkmode working by using "prefers-color-scheme" tag

### DIFF
--- a/_includes/default/head.liquid
+++ b/_includes/default/head.liquid
@@ -2,16 +2,25 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=0.5, maximum-scale=5">
 
-    <!-- Theme Mode-->
+    <!-- Theme Mode -->
     {% if site.color_theme == 'auto' %}
     <script>
         const isAutoTheme = true;
-        document.documentElement.setAttribute('data-theme', sessionStorage.getItem('theme'))
+        const prefersDarkMode = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        const storedTheme = localStorage.getItem('theme');
+
+        if (storedTheme) {
+            document.documentElement.setAttribute('data-theme', storedTheme);
+        } else if (prefersDarkMode) {
+            document.documentElement.setAttribute('data-theme', 'dark');
+        } else {
+            document.documentElement.setAttribute('data-theme', 'light');
+        }
     </script>
     {% else %}
     <script>
         const isAutoTheme = false;
-        document.documentElement.setAttribute('data-theme', "{{ site.color_theme | default: 'light' }}")
+        document.documentElement.setAttribute('data-theme', "{{ site.color_theme | default: 'light' }}");
     </script>
     {% endif %}
 


### PR DESCRIPTION
Laut Mozilla ist [prefers-color-scheme](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme) dafür verantwortlich, ob die Seite in light oder dark dargestellt werden soll. Sie fragt dafür die Systemeinstellung des Users ab.

Hat bei dem Test auch funktioniert :)