### PR TITLE
33 kalender an restliche webseite anpassen

### DIFF
--- a/_sass/base/_variables.scss
+++ b/_sass/base/_variables.scss
@@ -115,6 +115,32 @@ html[data-theme="dark"] {
   --base0f: #ff66c2; // Deprecated, Opening/Closing Embedded Language Tags, e.g. <?php ?>
 }
 
+// Fullcalendar light mode
+html, [data-theme="light"] {
+  --fc-page-bg-color: var(--background);
+  --fc-event-bg-color: var(--background);
+  --fc-event-text-color: var(--link);
+  --fc-event-border-color: var(--link);
+  --fc-button-bg-color: var(--background);
+  --fc-button-border-color: var(--link);
+  --fc-button-text-color: var(--link);
+  --fc-button-hover-bg-color: var(--meta);
+}
+
+// Fullcalendar dark mode
+html, [data-theme="dark"] {
+  --fc-page-bg-color: var(--background);
+  --fc-event-bg-color: var(--link);
+  --fc-event-border-color: var(--link);
+  --fc-event-border-color: var(--link);
+  --fc-today-bg-color: rgba(181, 125, 255, 0.15);
+  --fc-neutral-text-color: var(--fc-border-color);
+  --fc-button-bg-color: var(--background);
+  --fc-button-border-color: var(--link);
+  --fc-button-text-color: var(--link);
+  --fc-button-hover-bg-color: var(--meta);
+}
+
 // Monokai Theme
 //html[data-theme="dark"] {
 //  --base00: #272822; // Default Background

--- a/pages/01_events.md
+++ b/pages/01_events.md
@@ -37,6 +37,6 @@ icon: "far fa-calendar"
     </script>
   </head>
   <body>
-    <div id='calendar' style="width:80%; margin: auto;"></div>
+    <div id='calendar' style="width:95%; margin: auto;"></div>
   </body>
 </html>


### PR DESCRIPTION
Ich habe den Kalendar mal an das Theme angepasst und den Darkmode gefixt.

In Light-Mode sehen die Events anders aus, indem ich nur den Rahmen um den Event-Titel herum einfärbe. 
Dasselbe gilt für die Buttons.

Was ich leider bis jetzt noch nicht ändern konnte, sind die Größen der Schrift responsive zu machen.

Light:
![Screenshot 2023-11-04 at 14-53-22 Events](https://github.com/netz39/www.netz39.de/assets/12341832/0c3eea2c-7c4e-421c-a023-5786fa41aa69)

Dark: 
![Screenshot 2023-11-04 at 14-53-38 Events](https://github.com/netz39/www.netz39.de/assets/12341832/846cef35-09b8-4364-81cc-88537e1b324a)