### PR TITLE
Events/stammtisch wiki links

### DIFF
--- a/_events/2023-11-08_n39_stammtisch.md
+++ b/_events/2023-11-08_n39_stammtisch.md
@@ -7,4 +7,4 @@ event_date:   2023-11-08
 **Wann: 19:30 Uhr**\
 **Wo: Netz39 e.V.**
 
-Es ist wieder Vereins-Stammtisch! Wie immer in allen ganzzahlig durch drei teilbaren Kalenderwochen. Ihr findet vergangene und aktuelle Themen in unserem [Wiki](https://wiki.netz39.de/stammtisch:stammtisch). Protokoll dieses Stammtisches [hier](https://wiki.netz39.de/stammtisch:2023:2023-11-08).
+Es ist wieder Vereins-Stammtisch! Wie immer in allen ganzzahlig durch drei teilbaren Kalenderwochen. Das Protokoll dieses Stammtisches findet ihr [hier](https://wiki.netz39.de/stammtisch:2023:2023-11-08).

--- a/_events/2023-11-08_n39_stammtisch.md
+++ b/_events/2023-11-08_n39_stammtisch.md
@@ -7,4 +7,4 @@ event_date:   2023-11-08
 **Wann: 19:30 Uhr**\
 **Wo: Netz39 e.V.**
 
-Es ist wieder Vereins-Stammtisch! Wie immer an allen ganzzahlig durch drei teilbaren Kalenderwochen. Ihr findet vergangene und aktuelle Themen in unserem [Wiki](https://wiki.netz39.de/stammtisch:stammtisch).
+Es ist wieder Vereins-Stammtisch! Wie immer an allen ganzzahlig durch drei teilbaren Kalenderwochen. Ihr findet vergangene und aktuelle Themen in unserem [Wiki](https://wiki.netz39.de/stammtisch:stammtisch). Protokoll dieses Stammtisches [hier](https://wiki.netz39.de/stammtisch:2023:2023-11-08).

--- a/_events/2023-11-08_n39_stammtisch.md
+++ b/_events/2023-11-08_n39_stammtisch.md
@@ -7,4 +7,4 @@ event_date:   2023-11-08
 **Wann: 19:30 Uhr**\
 **Wo: Netz39 e.V.**
 
-Es ist wieder Vereins-Stammtisch! Wie immer an allen ganzzahlig durch drei teilbaren Kalenderwochen. Ihr findet vergangene und aktuelle Themen in unserem [Wiki](https://wiki.netz39.de/stammtisch:stammtisch). Protokoll dieses Stammtisches [hier](https://wiki.netz39.de/stammtisch:2023:2023-11-08).
+Es ist wieder Vereins-Stammtisch! Wie immer in allen ganzzahlig durch drei teilbaren Kalenderwochen. Ihr findet vergangene und aktuelle Themen in unserem [Wiki](https://wiki.netz39.de/stammtisch:stammtisch). Protokoll dieses Stammtisches [hier](https://wiki.netz39.de/stammtisch:2023:2023-11-08).

--- a/_events/2023-11-29_n39_stammtisch.md
+++ b/_events/2023-11-29_n39_stammtisch.md
@@ -7,4 +7,4 @@ event_date:   2023-11-29
 **Wann: 19:30 Uhr**\
 **Wo: Netz39 e.V.**
 
-Es ist wieder Vereins-Stammtisch! Wie immer an allen ganzzahlig durch drei teilbaren Kalenderwochen. Ihr findet vergangene und aktuelle Themen in unserem [Wiki](https://wiki.netz39.de/stammtisch:stammtisch). Protokoll dieses Stammtisches [hier](https://wiki.netz39.de/stammtisch:2023:2023-11-29).
+Es ist wieder Vereins-Stammtisch! Wie immer in allen ganzzahlig durch drei teilbaren Kalenderwochen. Ihr findet vergangene und aktuelle Themen in unserem [Wiki](https://wiki.netz39.de/stammtisch:stammtisch). Protokoll dieses Stammtisches [hier](https://wiki.netz39.de/stammtisch:2023:2023-11-29).

--- a/_events/2023-11-29_n39_stammtisch.md
+++ b/_events/2023-11-29_n39_stammtisch.md
@@ -7,4 +7,4 @@ event_date:   2023-11-29
 **Wann: 19:30 Uhr**\
 **Wo: Netz39 e.V.**
 
-Es ist wieder Vereins-Stammtisch! Wie immer in allen ganzzahlig durch drei teilbaren Kalenderwochen. Ihr findet vergangene und aktuelle Themen in unserem [Wiki](https://wiki.netz39.de/stammtisch:stammtisch). Protokoll dieses Stammtisches [hier](https://wiki.netz39.de/stammtisch:2023:2023-11-29).
+Es ist wieder Vereins-Stammtisch! Wie immer in allen ganzzahlig durch drei teilbaren Kalenderwochen. Das Protokoll dieses Stammtisches findet ihr [hier](https://wiki.netz39.de/stammtisch:2023:2023-11-29).

--- a/_events/2023-11-29_n39_stammtisch.md
+++ b/_events/2023-11-29_n39_stammtisch.md
@@ -7,4 +7,4 @@ event_date:   2023-11-29
 **Wann: 19:30 Uhr**\
 **Wo: Netz39 e.V.**
 
-Es ist wieder Vereins-Stammtisch! Wie immer an allen ganzzahlig durch drei teilbaren Kalenderwochen. Ihr findet vergangene und aktuelle Themen in unserem [Wiki](https://wiki.netz39.de/stammtisch:stammtisch).
+Es ist wieder Vereins-Stammtisch! Wie immer an allen ganzzahlig durch drei teilbaren Kalenderwochen. Ihr findet vergangene und aktuelle Themen in unserem [Wiki](https://wiki.netz39.de/stammtisch:stammtisch). Protokoll dieses Stammtisches [hier](https://wiki.netz39.de/stammtisch:2023:2023-11-29).

--- a/_events/2023-12-20_n39_stammtisch.md
+++ b/_events/2023-12-20_n39_stammtisch.md
@@ -7,4 +7,4 @@ event_date:   2023-12-20
 **Wann: 19:30 Uhr**\
 **Wo: Netz39 e.V.**
 
-Es ist wieder Vereins-Stammtisch! Wie immer an allen ganzzahlig durch drei teilbaren Kalenderwochen. Ihr findet vergangene und aktuelle Themen in unserem [Wiki](https://wiki.netz39.de/stammtisch:stammtisch).
+Es ist wieder Vereins-Stammtisch! Wie immer an allen ganzzahlig durch drei teilbaren Kalenderwochen. Ihr findet vergangene und aktuelle Themen in unserem [Wiki](https://wiki.netz39.de/stammtisch:stammtisch). Protokoll dieses Stammtisches [hier](https://wiki.netz39.de/stammtisch:2023:2023-12-20).

--- a/_events/2023-12-20_n39_stammtisch.md
+++ b/_events/2023-12-20_n39_stammtisch.md
@@ -7,4 +7,4 @@ event_date:   2023-12-20
 **Wann: 19:30 Uhr**\
 **Wo: Netz39 e.V.**
 
-Es ist wieder Vereins-Stammtisch! Wie immer in allen ganzzahlig durch drei teilbaren Kalenderwochen. Ihr findet vergangene und aktuelle Themen in unserem [Wiki](https://wiki.netz39.de/stammtisch:stammtisch). Protokoll dieses Stammtisches [hier](https://wiki.netz39.de/stammtisch:2023:2023-12-20).
+Es ist wieder Vereins-Stammtisch! Wie immer in allen ganzzahlig durch drei teilbaren Kalenderwochen. Das Protokoll dieses Stammtisches findet ihr [hier](https://wiki.netz39.de/stammtisch:2023:2023-12-20).

--- a/_events/2023-12-20_n39_stammtisch.md
+++ b/_events/2023-12-20_n39_stammtisch.md
@@ -7,4 +7,4 @@ event_date:   2023-12-20
 **Wann: 19:30 Uhr**\
 **Wo: Netz39 e.V.**
 
-Es ist wieder Vereins-Stammtisch! Wie immer an allen ganzzahlig durch drei teilbaren Kalenderwochen. Ihr findet vergangene und aktuelle Themen in unserem [Wiki](https://wiki.netz39.de/stammtisch:stammtisch). Protokoll dieses Stammtisches [hier](https://wiki.netz39.de/stammtisch:2023:2023-12-20).
+Es ist wieder Vereins-Stammtisch! Wie immer in allen ganzzahlig durch drei teilbaren Kalenderwochen. Ihr findet vergangene und aktuelle Themen in unserem [Wiki](https://wiki.netz39.de/stammtisch:stammtisch). Protokoll dieses Stammtisches [hier](https://wiki.netz39.de/stammtisch:2023:2023-12-20).


### PR DESCRIPTION
Habe "an ... Kalenderwochen" durch "in ... Kalenderwochen" ersetzt und den Link zum jeweils aktuellen Protokoll hinzugefügt.
Soll ich den allgemeinen Wiki-Link dann rauswerfen?