### PR TITLE
Store board members in config and fix wiki links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,6 +2,15 @@
 baseurl: "/"
 url: "https://www.netz39.de"
 
+# BOARD MEMBERS
+board:
+  chair:
+    name: "Maximilian Grau"
+    wiki: "mg-95"
+  deputy:
+    name: "Timo Herrmann"
+    wiki: "timo"
+
 # THEME-SPECIFIC CONFIGURATION
 title: Netz39 e.V.                                      # site's title
 description: "Magdeburger Hackerspace"                  # used by search engines

--- a/pages/09_impressum.md
+++ b/pages/09_impressum.md
@@ -20,8 +20,10 @@ show-in-footer: true
 
 ## Vertreten durch:
 
-- Maximilian Grau ([Link ins Wiki](https://www.netz39.de/wiki/user:mg-95))
-- Timo Herrmann ([Link ins Wiki](https://www.netz39.de/wiki/user:timo))
+
+
+- {{ site.board.chair.name }} {% if site.board.chair.wiki and site.board.chair.wiki != '' and site.board.chair.wiki != nil %}([Link ins Wiki](https://wiki.netz39.de/user:{{ site.board.chair.wiki }})){% endif %}
+- {{ site.board.deputy.name }} {% if site.board.deputy.wiki and site.board.deputy.wiki != '' and site.board.deputy.wiki != nil %}([Link ins Wiki](https://wiki.netz39.de/user:{{ site.board.deputy.wiki }})){% endif %}
 
 ## Kontakt
 

--- a/pages/10_datenschutz.md
+++ b/pages/10_datenschutz.md
@@ -17,7 +17,7 @@ Netz39 e.V.
 Leibnizstraße 32
 39104 Magdeburg
 Vertreten durch:
-den aktuellen Vorstand (siehe Impressum)
+{{ site.board.chair.name }}, {{ site.board.deputy.name }}
 ```
 
 ## Ihre Betroffenenrechte


### PR DESCRIPTION
Board member names are now stored in the configuration, which means:
* They can be updated from there without needing to know where in the various pages they appear.
* We can easily put names on the page "Datenschutzerklärung" (as we should)

Also the faulty wiki links have been fixed.