### PR TITLE
Fix obsolete Docker Compose call

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ Unsere Webseite setzt aus folgenden Gründen auf Jekyll, einen statischen Websit
 1. Docker und Docker Compose auf deinem System installieren
 2. Docker Container im root-Verzeichnis starten:
    ```bash
-   docker-compose up
+   docker compose up
    ```
 
    Der Jekyll-Buildserver wird nun in einem Docker-Container gestartet und ist unter `http://localhost:4000` verfügbar. Du kannst Änderungen vornehmen, und sie werden automatisch in Echtzeit aktualisiert.
-3. Nach der Entwicklung den Container mit `docker-compose down` beenden.
+3. Nach der Entwicklung den Container mit `docker compose down` beenden.
 
 ## git-lfs
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "2"
 services:
   jekyll:
       image: jekyll/jekyll:4


### PR DESCRIPTION
This pull request updates the Docker usage instructions and configuration in the project to align with the latest Docker Compose syntax and versioning.

### Updates to Docker usage:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L69-R73): Updated Docker commands to use the new `docker compose` syntax instead of the deprecated `docker-compose` commands.

### Updates to Docker configuration:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L1): Upgraded the Docker Compose file version from `2` to the latest syntax by removing the explicit version declaration.