### PR TITLE
fix(calendar-data): fix event color assignment

### DIFF
--- a/calendar-data.html
+++ b/calendar-data.html
@@ -9,9 +9,6 @@ permalink: /calendar-data/
 {% assign dark = "#22272e" %}
 {% assign light = "#FFFFFF" %}
 
-{% assign backgroundColor = dark %}
-{% assign textColor = gradientBlueOrange2 %}
-
 {% assign gradientBlueOrange0 = "#4ddbff" %}
 {% assign gradientBlueOrange1 = "#6bc8d5" %}
 {% assign gradientBlueOrange2 = "#89b5ab" %}
@@ -24,6 +21,8 @@ permalink: /calendar-data/
 {% for event in site.events %}
   {% if has_previous %},{% endif %}
   {% assign has_previous = true %}
+  {% assign backgroundColor = dark %}
+  {% assign textColor = gradientBlueOrange2 %}
   {
     "title": {{ event.title | jsonify }},
     "start": "{{ event.event.start | date: "%Y-%m-%dT%H:%M:%S" }}",
@@ -42,10 +41,7 @@ permalink: /calendar-data/
             {% elsif tag == "recurring" %}
                 {% assign backgroundColor = gradientBlueOrange2 %}
                 {% assign textColor = dark %}
-            {% else %}
-                {% assign backgroundColor = dark %}
-                {% assign textColor = gradientBlueOrange2 %}
-            {% endif %}
+            {% endif  %}
         {% endfor %}
     {% endif %}
     "backgroundColor": "{{ backgroundColor }}",


### PR DESCRIPTION
see #236 

Wir gehen mit mehrfach getaggten events derzeit so um, dass der letzte tag die Farbe bestimmt. In diesem Fall non-recurring. Mmn sollte aber non-recurring ignoriert werden, da es genau so aussieht wie der default. Alternative wäre gewesen im bot die Reihenfolge anzupassen. Dann hätten wir das Problem aber erneut sobal jemand manuell ein event erstellt mit besagter Reihenfolge.

Des weiteren werden derzeit die vars backgroundColor und textColor auf dokument ebene assigned, sollten aber natürlich pro event assigned werden. Folge ist, dass ein event per default die selbe Farbe wie sein Vorgänger hat, es sein denn es ist getagged.
