### PR TITLE
feat[_events]: fix _events/2025/discord-event-1415406548922142741.md

### DIFF
--- a/_events/2025/discord-event-1415406548922142741.md
+++ b/_events/2025/discord-event-1415406548922142741.md
@@ -17,7 +17,7 @@ Anmeldung und Fragen unter endof10@netz39.de
 
 Weitere Termine: 
 
-[25.10.2025 16:00Uhr](http://localhost:4000/events/2025/discord-event-1415407086317342792 )
+[25.10.2025 16:00Uhr](https://www.netz39.de/events/2025/discord-event-1415407086317342792 )
 
 #internal
 <!-- event imported from discord manual changes may be overwritten -->


### PR DESCRIPTION
Updated the event link in `_events/2025/discord-event-1415406548922142741.md` from `http://localhost:4000` to `https://www.netz39.de`