### PR TITLE
add softwerke linux stammtisch events for 2026

### DIFF
--- a/_events/2026/2026-02-26_linux_stammtisch.md
+++ b/_events/2026/2026-02-26_linux_stammtisch.md
@@ -1,0 +1,11 @@
+---
+layout: event
+title: "Linux-Stammtisch"
+tags: [non-recurring,external]
+event:
+  start: 2026-02-26 19:30:00
+  end: 2026-02-26 21:30:00
+author: softwerke
+---
+
+Am Donnerstag dem 26. Februar 2026 findet der Linux-Stammtisch der Softwerke Magdeburg e. V. bei uns im Space statt!

--- a/_events/2026/2026-05-28_linux_stammtisch.md
+++ b/_events/2026/2026-05-28_linux_stammtisch.md
@@ -1,0 +1,11 @@
+---
+layout: event
+title: "Linux-Stammtisch"
+tags: [non-recurring,external]
+event:
+  start: 2026-05-28 19:30:00
+  end: 2026-05-28 21:30:00
+author: softwerke
+---
+
+Am Donnerstag dem 28. Mai 2026 findet der Linux-Stammtisch der Softwerke Magdeburg e. V. bei uns im Space statt!

--- a/_events/2026/2026-08-27_linux_stammtisch.md
+++ b/_events/2026/2026-08-27_linux_stammtisch.md
@@ -1,0 +1,11 @@
+---
+layout: event
+title: "Linux-Stammtisch"
+tags: [non-recurring,external]
+event:
+  start: 2026-08-27 19:30:00
+  end: 2026-08-27 21:30:00
+author: softwerke
+---
+
+Am Donnerstag dem 27. August 2026 findet der Linux-Stammtisch der Softwerke Magdeburg e. V. bei uns im Space statt!

--- a/_events/2026/2026-11-26_linux_stammtisch.md
+++ b/_events/2026/2026-11-26_linux_stammtisch.md
@@ -1,0 +1,11 @@
+---
+layout: event
+title: "Linux-Stammtisch"
+tags: [non-recurring,external]
+event:
+  start: 2026-11-26 19:30:00
+  end: 2026-11-26 21:30:00
+author: softwerke
+---
+
+Am Donnerstag dem 26. November 2026 findet der Linux-Stammtisch der Softwerke Magdeburg e. V. bei uns im Space statt!


### PR DESCRIPTION
Die Termine wurden mit dem Skript aus #200 erzeugt. Sie stimmen mit den offiziell angekündigten Terminen auf der Softwerke-Homepage überein.