### PR TITLE
add softwerke stammtisch events for 2026

### DIFF
--- a/_events/2026/2026-01-09_softwerke_stammtisch.md
+++ b/_events/2026/2026-01-09_softwerke_stammtisch.md
@@ -1,0 +1,11 @@
+---
+layout: event
+title: "Softwerke-Stammtisch"
+tags: [recurring,external]
+event:
+  start: 2026-01-09 19:30:00
+  end: 2026-01-09 21:30:00
+author: softwerke
+---
+
+Am Freitag dem 9. Januar 2026 findet der Stammtisch der Softwerke Magdeburg e. V. bei uns im Space statt!

--- a/_events/2026/2026-02-13_softwerke_stammtisch.md
+++ b/_events/2026/2026-02-13_softwerke_stammtisch.md
@@ -1,0 +1,11 @@
+---
+layout: event
+title: "Softwerke-Stammtisch"
+tags: [recurring,external]
+event:
+  start: 2026-02-13 19:30:00
+  end: 2026-02-13 21:30:00
+author: softwerke
+---
+
+Am Freitag dem 13. Februar 2026 findet der Stammtisch der Softwerke Magdeburg e. V. bei uns im Space statt!

--- a/_events/2026/2026-03-13_softwerke_stammtisch.md
+++ b/_events/2026/2026-03-13_softwerke_stammtisch.md
@@ -1,0 +1,11 @@
+---
+layout: event
+title: "Softwerke-Stammtisch"
+tags: [recurring,external]
+event:
+  start: 2026-03-13 19:30:00
+  end: 2026-03-13 21:30:00
+author: softwerke
+---
+
+Am Freitag dem 13. März 2026 findet der Stammtisch der Softwerke Magdeburg e. V. bei uns im Space statt!

--- a/_events/2026/2026-04-10_softwerke_stammtisch.md
+++ b/_events/2026/2026-04-10_softwerke_stammtisch.md
@@ -1,0 +1,11 @@
+---
+layout: event
+title: "Softwerke-Stammtisch"
+tags: [recurring,external]
+event:
+  start: 2026-04-10 19:30:00
+  end: 2026-04-10 21:30:00
+author: softwerke
+---
+
+Am Freitag dem 10. April 2026 findet der Stammtisch der Softwerke Magdeburg e. V. bei uns im Space statt!

--- a/_events/2026/2026-05-08_softwerke_stammtisch.md
+++ b/_events/2026/2026-05-08_softwerke_stammtisch.md
@@ -1,0 +1,11 @@
+---
+layout: event
+title: "Softwerke-Stammtisch"
+tags: [recurring,external]
+event:
+  start: 2026-05-08 19:30:00
+  end: 2026-05-08 21:30:00
+author: softwerke
+---
+
+Am Freitag dem 8. Mai 2026 findet der Stammtisch der Softwerke Magdeburg e. V. bei uns im Space statt!

--- a/_events/2026/2026-06-12_softwerke_stammtisch.md
+++ b/_events/2026/2026-06-12_softwerke_stammtisch.md
@@ -1,0 +1,11 @@
+---
+layout: event
+title: "Softwerke-Stammtisch"
+tags: [recurring,external]
+event:
+  start: 2026-06-12 19:30:00
+  end: 2026-06-12 21:30:00
+author: softwerke
+---
+
+Am Freitag dem 12. Juni 2026 findet der Stammtisch der Softwerke Magdeburg e. V. bei uns im Space statt!

--- a/_events/2026/2026-07-10_softwerke_stammtisch.md
+++ b/_events/2026/2026-07-10_softwerke_stammtisch.md
@@ -1,0 +1,11 @@
+---
+layout: event
+title: "Softwerke-Stammtisch"
+tags: [recurring,external]
+event:
+  start: 2026-07-10 19:30:00
+  end: 2026-07-10 21:30:00
+author: softwerke
+---
+
+Am Freitag dem 10. Juli 2026 findet der Stammtisch der Softwerke Magdeburg e. V. bei uns im Space statt!

--- a/_events/2026/2026-08-14_softwerke_stammtisch.md
+++ b/_events/2026/2026-08-14_softwerke_stammtisch.md
@@ -1,0 +1,11 @@
+---
+layout: event
+title: "Softwerke-Stammtisch"
+tags: [recurring,external]
+event:
+  start: 2026-08-14 19:30:00
+  end: 2026-08-14 21:30:00
+author: softwerke
+---
+
+Am Freitag dem 14. August 2026 findet der Stammtisch der Softwerke Magdeburg e. V. bei uns im Space statt!

--- a/_events/2026/2026-09-11_softwerke_stammtisch.md
+++ b/_events/2026/2026-09-11_softwerke_stammtisch.md
@@ -1,0 +1,11 @@
+---
+layout: event
+title: "Softwerke-Stammtisch"
+tags: [recurring,external]
+event:
+  start: 2026-09-11 19:30:00
+  end: 2026-09-11 21:30:00
+author: softwerke
+---
+
+Am Freitag dem 11. September 2026 findet der Stammtisch der Softwerke Magdeburg e. V. bei uns im Space statt!

--- a/_events/2026/2026-10-09_softwerke_stammtisch.md
+++ b/_events/2026/2026-10-09_softwerke_stammtisch.md
@@ -1,0 +1,11 @@
+---
+layout: event
+title: "Softwerke-Stammtisch"
+tags: [recurring,external]
+event:
+  start: 2026-10-09 19:30:00
+  end: 2026-10-09 21:30:00
+author: softwerke
+---
+
+Am Freitag dem 9. Oktober 2026 findet der Stammtisch der Softwerke Magdeburg e. V. bei uns im Space statt!

--- a/_events/2026/2026-11-13_softwerke_stammtisch.md
+++ b/_events/2026/2026-11-13_softwerke_stammtisch.md
@@ -1,0 +1,11 @@
+---
+layout: event
+title: "Softwerke-Stammtisch"
+tags: [recurring,external]
+event:
+  start: 2026-11-13 19:30:00
+  end: 2026-11-13 21:30:00
+author: softwerke
+---
+
+Am Freitag dem 13. November 2026 findet der Stammtisch der Softwerke Magdeburg e. V. bei uns im Space statt!

--- a/_events/2026/2026-12-11_softwerke_stammtisch.md
+++ b/_events/2026/2026-12-11_softwerke_stammtisch.md
@@ -1,0 +1,11 @@
+---
+layout: event
+title: "Softwerke-Stammtisch"
+tags: [recurring,external]
+event:
+  start: 2026-12-11 19:30:00
+  end: 2026-12-11 21:30:00
+author: softwerke
+---
+
+Am Freitag dem 11. Dezember 2026 findet der Stammtisch der Softwerke Magdeburg e. V. bei uns im Space statt!


### PR DESCRIPTION
Die Events entsprechen den offiziell angekündigten Terminen auf der Softwerke-Homepage.
Sie wurden mit dem Python-Skript aus #313 erzeugt.