### PR TITLE
Add Matrix contact information to footer

### DIFF
--- a/_data/icons.yml
+++ b/_data/icons.yml
@@ -17,7 +17,7 @@ linkedin:
 mail: kontakt@netz39.de # e.g. "sam@mail.com"
 map: ?mlat=52.1195724&mlon=11.6291814 #52.1195724/11.6291814 # e.g. "34.0886/-118.3191"
 mastodon: machteburch.social/@netz39 # e.g. "fostodon.org/@sam"
-matrix:           # e.g. "@sam:matrix.org"
+matrix: "#netz39:netz39.de"
 medium:
 patreon:
 phone:            # e.g. "+11111111111"

--- a/_data/icons_builder.yml
+++ b/_data/icons_builder.yml
@@ -39,7 +39,6 @@ mastodon:
   pre: "https://"
 matrix:
   pre: "https://matrix.to/#/"
-  icon: "fab fa-connectdevelop"
 medium:
   pre: "https://medium.com/@"
 patreon:

--- a/_sass/includes/_matrix_icon.scss
+++ b/_sass/includes/_matrix_icon.scss
@@ -1,0 +1,22 @@
+.fa-matrix {
+  --icon-color: currentColor;
+
+  &:before {
+    content: "";
+    display: inline-block;
+    width: 1em;
+    height: 1em;
+    vertical-align: -0.125em;
+
+    mask: url("https://cdn.netz39.de/img/logo/matrix-icon.svg") no-repeat center / contain;
+    -webkit-mask: url("https://cdn.netz39.de/img/matrix-icon.svg") no-repeat center / contain; // Safari
+
+    background-color: var(--icon-color);
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .fa-matrix {
+    --icon-color: #fff;
+  }
+}

--- a/_sass/type-on-strap.scss
+++ b/_sass/type-on-strap.scss
@@ -28,6 +28,7 @@
 @import "includes/gallery";
 @import "includes/portfolio";
 @import "includes/sponsors_banner";
+@import "includes/matrix_icon";
 
 /* Posts */
 // Linked with the html in the _layouts folder

--- a/pages/kontakt.md
+++ b/pages/kontakt.md
@@ -14,6 +14,7 @@ icon: far fa-comments
 - Wer eine Frage hat, kann an <kontakt@netz39.de> schreiben
 - Wir sind auf Discord ([Invite-Link](https://discord.netz39.de))
 - Wir hosten unseren eigenen offenen XMPP multi-user-chat (MUC): [lounge@conference.jabber.n39.eu](xmpp:lounge@conference.jabber.n39.eu?join)
+- Unsere Discord-Channel sind auf Matrix gebrückt ([Matrix-Space](https://matrix.to/#/#netz39:netz39.de))
 
 ## Allgemeine Informationen für Interessenten
 


### PR DESCRIPTION
This will add our Matrix Server to the list of socials at the bottom of the page. As there is no official matrix icon available from font-awesome, the icon has been implemented via SCSS and an SVG. This implementation provides a class called `fa-matrix`, which can be used like any other font-awesome icon. 

This PR depends on https://github.com/netz39/cdn.netz39.de/pull/16.